### PR TITLE
Change theme of the webpage 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@
 
 # theme                  : "minimal-mistakes-jekyll"
 # remote_theme           : "mmistakes/minimal-mistakes"
-minimal_mistakes_skin    : "default" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
+minimal_mistakes_skin    : "contrast" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 # Site Settings
 locale                   : "en-US"
 rtl                      : # true, false (default) # turns direction of the page into right to left for RTL languages

--- a/_posts/2025-11-23-JekyII-Configuration.md
+++ b/_posts/2025-11-23-JekyII-Configuration.md
@@ -12,7 +12,7 @@ header:
 author_profile: true
 mathjax: true
 custom_css:
-  - /assets/css/about-page.css
+  - /assets/css/components.css
 ---
 
 # Complete Minimal Mistakes Theme Configuration

--- a/_posts/2025-11-23-using-css-design.md
+++ b/_posts/2025-11-23-using-css-design.md
@@ -12,7 +12,7 @@ header:
 author_profile: true
 mathjax: true
 custom_css:
-  - /assets/css/about-page.css
+  - /assets/css/components.css
 ---
 
 - [Quick Start](#quick-start)


### PR DESCRIPTION
# What changed (high level)

- Switched the Minimal Mistakes skin to use the "contrast" variant.
- Updated two post front-matter entries to load the new components.css  instead of the old about-page.css.